### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ﻿---
 BasedOnStyle: Google
+ColumnLimit: 100
 IndentWidth: '4'
-SortIncludes: false
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+﻿---
+BasedOnStyle: Google
+IndentWidth: '4'
+SortIncludes: false
+...


### PR DESCRIPTION
Adds `.clang-format` to the root directory of the project. I haven't thoroughly inspected our style guide compared with google's style guide. It seems to work for the most important parts though (80 char limit, spacing around operators, etc.) 

Style guide here: https://uwarg-docs.atlassian.net/l/cp/od6C36tN

You can try the settings for clang format on this live code page: https://zed0.co.uk/clang-format-configurator/