### PR TITLE
Add zp_assert

### DIFF
--- a/Common/Inc/assert.h
+++ b/Common/Inc/assert.h
@@ -1,0 +1,6 @@
+#ifndef ASSERT_H
+#define ASSERT_H
+
+void zp_assert(bool expr);
+
+#endif  // ASSERT_H

--- a/Common/Src/assert.c
+++ b/Common/Src/assert.c
@@ -1,0 +1,10 @@
+#include "assert.h"
+#include <stdbool.h>
+
+void zp_assert(bool expr) {
+    if (expr) {
+#warning This should call the los hardfault handler, or something more appropriate
+        while (1) {
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds an assert for use in ZP. This is to ensure we have a assertion function that we can use safely tear down in the event of a programming error. This assertion function will need to be properly defined with desired functionality (e.g. call the hardfault handler, stop motors, etc.) which will likely depend on LOS

https://github.com/UWARG/ZeroPilot-SW-3/pull/10#discussion_r1020834995

## Testing

No testing has been done. Implementation still needs to be defined

## Documentation

No  documentation created

# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
~- [ ] The code has been tested on hardware, either by me or someone else.~ Implementation not yet defined
~- [ ] Comprehensive unit tests have been made for this change~ Unit tests not functional
~- [ ] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.~ No documentation required
~- [ ] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.~ Builds are not functioning
