### PR TITLE
Add GlobalFlag Object

### DIFF
--- a/Common/Inc/GlobalFlag.hpp
+++ b/Common/Inc/GlobalFlag.hpp
@@ -31,7 +31,7 @@ class GlobalFlag {
         SemaphoreHandle_t flagResourceMux;
         SemaphoreHandle_t readerCountMux;
         SemaphoreHandle_t serviceQueue;
-        // Constant of ticks until 1ms
+        // Constant of ticks until timeout
         static const TickType_t TIMEOUT;
 
 };

--- a/Common/Inc/GlobalFlag.hpp
+++ b/Common/Inc/GlobalFlag.hpp
@@ -27,10 +27,10 @@ class GlobalFlag {
 
     private:
         bool flag;
-        int readerCount = 0;
-        SemaphoreHandle_t flagResourceMux;
-        SemaphoreHandle_t readerCountMux;
-        SemaphoreHandle_t serviceQueue;
+        int reader_count = 0;
+        SemaphoreHandle_t flag_resource_mux;
+        SemaphoreHandle_t reader_count_mux;
+        SemaphoreHandle_t service_queue;
         // Constant of ticks until timeout
         static const TickType_t TIMEOUT;
 

--- a/Common/Inc/GlobalFlag.hpp
+++ b/Common/Inc/GlobalFlag.hpp
@@ -1,0 +1,39 @@
+/*
+ * GlobalFlag.hpp
+ *
+ * Global Flag Header
+ *
+ * Created on: Nov 29, 2022
+ * Author(s): Gordon Fountain
+ */
+
+#ifndef ZPSW3_GLOBAL_FLAG_HPP
+#define ZPSW3_GLOBAL_FLAG_HPP
+
+#include "FreeRTOS.h"
+
+class GlobalFlag {
+    public:
+        GlobalFlag(bool flag_value = false, int timeout_ms = 1) :: TIMEOUT(timeout_ms / portTICK_PERIOD_MS) {
+            flag = flag_value;
+            flagResourceMux = xSemaphoreCreateMutex();
+            readerCountMux = xSemaphoreCreateMutex();
+            serviceQueue = xSemaphoreCreateCounting(10, 1);
+        };
+
+        void writeFlag(bool new_value);
+
+        bool readFlag();
+
+    private:
+        bool flag;
+        int readerCount = 0;
+        SemaphoreHandle_t flagResourceMux;
+        SemaphoreHandle_t readerCountMux;
+        SemaphoreHandle_t serviceQueue;
+        // Constant of ticks until 1ms
+        static const TickType_t TIMEOUT;
+
+};
+
+#endif  // ZPSW3_GLOBAL_FLAG_HPP

--- a/Common/Src/GlobalFlag.cpp
+++ b/Common/Src/GlobalFlag.cpp
@@ -1,0 +1,54 @@
+/*
+ * GlobalFlag.cpp
+ *
+ * Global Flag
+ *
+ * Created on: Nov 29, 2022
+ * Author(s): Gordon Fountain
+ */
+
+#include "GlobalFlag.hpp"
+
+void GlobalFlag::writeFlag(bool new_value) {
+    // Take spot in line for service
+    xSemaphoreTake(serviceQueue, TIMEOUT);
+    // Once at front take the resource mutex
+    xSemaphoreTake(flagResourceMux, TIMEOUT);
+    // Let next in line get served now that resource is held
+    xSemaphoreGive(serviceQueue);
+    // Write to the flag
+    flag = new_value;
+    // Release resource mux
+    xSemaphoreGive(flagResourceMux);
+}
+
+bool GlobalFlag::readFlag() {
+    // Take spot in line for service
+    xSemaphoreTake(serviceQueue, TIMEOUT);
+    // Once at front of line take the reader count mutex
+    xSemaphoreTake(readerCountMux, TIMEOUT);
+    // Increment the number of readers accessing resource
+    readerCount++;
+    // If this is the first reader then take the resource mutex
+    if (readerCount == 1) {
+        xSemaphoreTake(flagResourceMux, TIMEOUT);
+    }
+    // Let the next call get service
+    xSemaphoreGive(serviceQueue);
+    // Release the reader count mutex to the next reader
+    xSemaphoreGive(readerCountMux);
+    // Store the flag value
+    bool return_value = flag;
+    // Get the reader count mutex
+    xSemaphoreTake(readerCountMux, TIMEOUT);
+    // Decrement the number of readers
+    readerCount--;
+    // Check if all readers are finished to release resource
+    if (readerCount == 0) {
+        xSemaphoreGive(flagResourceMux);
+    }
+    // Release reader count mutex
+    xSemaphoreGive(readerCountMux);
+    // Return the stored value
+    return return_value;
+}

--- a/Common/Src/GlobalFlag.cpp
+++ b/Common/Src/GlobalFlag.cpp
@@ -7,7 +7,7 @@
  * Author(s): Gordon Fountain
  */
 
-#include "GlobalFlag.hpp"
+#include "../Inc/GlobalFlag.hpp"
 
 void GlobalFlag::writeFlag(bool new_value) {
     // Take spot in line for service

--- a/Common/Src/GlobalFlag.cpp
+++ b/Common/Src/GlobalFlag.cpp
@@ -11,44 +11,44 @@
 
 void GlobalFlag::writeFlag(bool new_value) {
     // Take spot in line for service
-    xSemaphoreTake(serviceQueue, TIMEOUT);
+    xSemaphoreTake(service_queue, TIMEOUT);
     // Once at front take the resource mutex
-    xSemaphoreTake(flagResourceMux, TIMEOUT);
+    xSemaphoreTake(flag_resource_mux, TIMEOUT);
     // Let next in line get served now that resource is held
-    xSemaphoreGive(serviceQueue);
+    xSemaphoreGive(service_queue);
     // Write to the flag
     flag = new_value;
     // Release resource mux
-    xSemaphoreGive(flagResourceMux);
+    xSemaphoreGive(flag_resource_mux);
 }
 
 bool GlobalFlag::readFlag() {
     // Take spot in line for service
-    xSemaphoreTake(serviceQueue, TIMEOUT);
+    xSemaphoreTake(service_queue, TIMEOUT);
     // Once at front of line take the reader count mutex
-    xSemaphoreTake(readerCountMux, TIMEOUT);
+    xSemaphoreTake(reader_count_mux, TIMEOUT);
     // Increment the number of readers accessing resource
-    readerCount++;
+    reader_count++;
     // If this is the first reader then take the resource mutex
-    if (readerCount == 1) {
-        xSemaphoreTake(flagResourceMux, TIMEOUT);
+    if (reader_count == 1) {
+        xSemaphoreTake(flag_resource_mux, TIMEOUT);
     }
     // Let the next call get service
-    xSemaphoreGive(serviceQueue);
+    xSemaphoreGive(service_queue);
     // Release the reader count mutex to the next reader
-    xSemaphoreGive(readerCountMux);
+    xSemaphoreGive(reader_count_mux);
     // Store the flag value
     bool return_value = flag;
     // Get the reader count mutex
-    xSemaphoreTake(readerCountMux, TIMEOUT);
+    xSemaphoreTake(reader_count_mux, TIMEOUT);
     // Decrement the number of readers
-    readerCount--;
+    reader_count--;
     // Check if all readers are finished to release resource
-    if (readerCount == 0) {
-        xSemaphoreGive(flagResourceMux);
+    if (reader_count == 0) {
+        xSemaphoreGive(flag_resource_mux);
     }
     // Release reader count mutex
-    xSemaphoreGive(readerCountMux);
+    xSemaphoreGive(reader_count_mux);
     // Return the stored value
     return return_value;
 }


### PR DESCRIPTION
# Description

Added a GlobalFlag object that handles reading and writing from different threads using service queue-based mutexes,

## Testing

Can be tested once added into main code.

## Documentation

https://en.wikipedia.org/wiki/Readers%E2%80%93writers_problem#Third_readers%E2%80%93writers_problem

# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
- [x] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.
