### PR TITLE
Add Fixed Manual Controller

### DIFF
--- a/AttitudeManager/ControlAlgorithms/Inc/AM_FixedControl.hpp
+++ b/AttitudeManager/ControlAlgorithms/Inc/AM_FixedControl.hpp
@@ -27,7 +27,7 @@ class FixedControl : public ControlInterface {
 
     void updatePid() override { return; }
 
-   private:
+   protected:
     enum ActuatorIdx {
         Engine = 0,
         LeftAileron,
@@ -36,6 +36,10 @@ class FixedControl : public ControlInterface {
         Elevator,
         NumActuatorIdx  // Must always be last
     };
+
+    const ActuatorConfig configs[NumActuatorIdx];
+    
+   private:
 
 // TODO: Implement different fixed wing controls algorithms
 // class FixedControlAcro : public AM::FixedControl {
@@ -70,7 +74,6 @@ class FixedControl : public ControlInterface {
 //     private: 
 // };
 
-    const ActuatorConfig configs[NumActuatorIdx];
     
     static constexpr float MAX_BANK_ANGLE = 20;   // Max angle defined in degrees. 
     static constexpr float MAX_PITCH_ANGLE = 20;  // Max angle defined in degrees. 

--- a/AttitudeManager/ControlAlgorithms/Inc/AM_FixedManualControl.hpp
+++ b/AttitudeManager/ControlAlgorithms/Inc/AM_FixedManualControl.hpp
@@ -1,0 +1,36 @@
+/*
+ * AM_FixedControl.hpp
+ *
+ * Attitude Manager Level Mode Quad Controller Algorithm
+ *
+ * Created on: Oct 22, 2022
+ * Author(s): Aidan Bowers, Jack Greenwood
+ */
+#ifndef ZPSW3_AM_ACRO_FIXED_CONTROL_HPP
+#define ZPSW3_AM_ACRO_FIXED_CONTROL_HPP
+
+#include "AM_FixedControl.hpp"
+#include "PID.hpp"
+
+namespace AM {
+
+class ManualFixedControl : public FixedControl {
+   public:
+    ManualFixedControl(ActuatorConfig &engine, ActuatorConfig &leftAileron,
+                       ActuatorConfig &rightAileron, ActuatorConfig &rudder,
+                       ActuatorConfig &elevator)
+        : FixedControl(engine, leftAileron, rightAileron, rudder, elevator) {};
+
+    std::vector<ActuatorOutput> runControlsAlgorithm(
+        const AttitudeManagerInput &instructions) override;
+
+   private:
+    float ManualFixedControl::mixOutputs(StateMix actuator,
+                                         float bank,
+                                         float pitch,
+                                         float yaw,
+                                         float throttle) const;
+};
+}  // namespace AM
+
+#endif  // ZPSW3_AM_ACRO_FIXED_CONTROL_HPP

--- a/AttitudeManager/ControlAlgorithms/Src/AM_FixedManualControl.cpp
+++ b/AttitudeManager/ControlAlgorithms/Src/AM_FixedManualControl.cpp
@@ -1,0 +1,44 @@
+#include "AM_FixedManualControl.hpp"
+
+namespace AM {
+
+std::vector<ActuatorOutput> ManualFixedControl::runControlsAlgorithm(
+    const AttitudeManagerInput &instructions) {
+   
+    // Compute target values, measured as percent of maximum surface deflection
+    float yaw = instructions.heading / 360 * 100;
+    float throttle = instructions.z_dir * 100; 
+    float pitch = instructions.x_dir * 100;
+    float bank = instructions.y_dir * 100;  
+
+    // mix the targets
+    float engine_output = 
+        mixOutputs(configs[Engine].stateMix, bank, pitch, yaw, throttle);
+    float left_aileron_output = 
+        mixOutputs(configs[LeftAileron].stateMix, bank, pitch, yaw, throttle);
+    float right_aileron_output = 
+        mixOutputs(configs[RightAileron].stateMix, bank, pitch, yaw, throttle);
+    float rudder = 
+        mixOutputs(configs[Rudder].stateMix, bank, pitch, yaw, throttle);
+    float elevator = 
+        mixOutputs(configs[Elevator].stateMix, bank, pitch, yaw, throttle);
+    
+    return std::vector<ActuatorOutput> {
+        {configs[Engine].channel, engine_output},
+        {configs[LeftAileron].channel, left_aileron_output},
+        {configs[RightAileron].channel, right_aileron_output},
+        {configs[Rudder].channel, rudder},
+        {configs[Elevator].channel, elevator}
+    };
+}
+
+float ManualFixedControl::mixOutputs(StateMix actuator, float bank, float pitch, float yaw,
+                  float throttle) const {
+    return constrain<float>(actuator.pitch * pitch + actuator.roll * bank +
+                                actuator.yaw * yaw +
+                                actuator.velocity_x * throttle,
+                            100, 0);
+
+}
+
+} // namespace AM


### PR DESCRIPTION
# Description

Adds a fixed wing controller that essentially acts similarly to a ppm passthrough (but makes use of the state mix to decide what control surfaces to manipulate) as sensorfusion will not be ready by the time we need to do a flight test

## Testing

No unit tests were created, and the code is totally untested. Heck, I don't think it even builds properly.

## Documentation

I have no documentation

# Merge Checklist:

~- [ ] The changes have been well commented, particularly in hard-to-understand areas.~
~- [ ] The code has been tested on hardware, either by me or someone else.~
~- [ ] Comprehensive unit tests have been made for this change~
~- [ ] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.~
- [ ] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.
Ignore these check boxes that I'm bypassing unless someone is willing to test the code :/ Don't merge unless this thing builds, please.